### PR TITLE
Answer to your question on RStudio Community

### DIFF
--- a/example-cv.Rmd
+++ b/example-cv.Rmd
@@ -9,6 +9,15 @@ output:
     css: ["custom-styles.css", "resume"]
 ---
 
+```{css, echo=FALSE}
+.pagedjs_page:not(:first-of-type) {
+  --sidebar-width: 0rem;
+  --sidebar-background-color: #ffffff;
+  --main-width: calc(var(--content-width) - var(--sidebar-width));
+  --decorator-horizontal-margin: 0.2in;
+}
+```
+
 Aside
 ================================================================================
 

--- a/example-cv.html
+++ b/example-cv.html
@@ -7,11 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <meta name="author" content="Lijia Yu" />
-    <meta name="date" content="2021-04-29" />
+    <meta name="date" content="2021-05-01" />
     <title>Lijia Yu’s resume</title>
 
     
-        <script src="example-cv_files/header-attrs-2.7.12/header-attrs.js"></script>
+        <script src="example-cv_files/header-attrs-2.7/header-attrs.js"></script>
         <link href="example-cv_files/font-awesome-5.1.0/css/all.css" rel="stylesheet" />
         <link href="example-cv_files/font-awesome-5.1.0/css/v4-shims.css" rel="stylesheet" />
         <link href="example-cv_files/paged-0.14/css/resume.css" rel="stylesheet" />
@@ -24,6 +24,14 @@
   </head>
   <body>
 
+<style type="text/css">
+.pagedjs_page:not(:first-of-type) {
+  --sidebar-width: 0rem;
+  --sidebar-background-color: #ffffff;
+  --main-width: calc(var(--content-width) - var(--sidebar-width));
+  --decorator-horizontal-margin: 0.2in;
+}
+</style>
 <div id="aside" class="section level1">
 <h1>Aside</h1>
 <p><img src="https://avatars1.githubusercontent.com/u/895125?s=400&amp;v=4" style="width:80.0%" alt="Lijia Yu" /></p>
@@ -47,7 +55,7 @@
 <div id="disclaimer" class="section level2">
 <h2>Disclaimer</h2>
 <p>This resume was made with the R package <a href="https://github.com/rstudio/pagedown"><strong>pagedown</strong></a>.</p>
-<p>Last updated on 2021-04-29.</p>
+<p>Last updated on 2021-05-01.</p>
 </div>
 </div>
 <div id="main" class="section level1">


### PR DESCRIPTION
Hi @wjakethompson,

I've seen [your question on RStudio Community](https://community.rstudio.com/t/pagedown-resume-with-one-page-aside-pagedown-0-14/103299).

I'm so sorry that **pagedown** 0.14 broke your resume. This bug is related to https://github.com/rstudio/pagedown/issues/211. This is a regression introduced in Paged.js. I hadn't had time to investigate its origin.

As a workaround, we can use a trick to bypass this bug: Paged.js only inspects the CSS `style` elements which are the `head` element. If we include a `style` element in the `body`, Paged.js ignores it. That's absolutely not satisfying but it works :wink: 

I will crosspost this answer on RSC.